### PR TITLE
feat: Change dev port from 5000 to 5900

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To start your Phoenix server:
   * Run `mix setup` to install and setup dependencies
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
-Now you can visit [`localhost:5000`](http://localhost:5000) from your browser.
+Now you can visit [`localhost:5900`](http://localhost:5900) from your browser.
 
 If you need to configure the CouchDB to use, you can use the `TOOLBOX_DB_AUTH`
 and `TOOLBOX_DB_URL` env variables:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,7 @@ config :toolbox, Web.Endpoint,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :toolbox, Web.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 5000],
+  http: [ip: {127, 0, 0, 1}, port: 5900],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,


### PR DESCRIPTION
On MacOS, the port 5000 is already taken by AirPlay, so we want to change cozy-toolbox's port for 5900